### PR TITLE
Handling exceptions.ImportError for environments without ibus.

### DIFF
--- a/autoload/ibus.vim
+++ b/autoload/ibus.vim
@@ -23,25 +23,28 @@ endfunction
 function! s:is_enabled()
   python << EOT
 import vim
-import ibus
-from dbus.exceptions import DBusException
-bus = ibus.Bus()
 try:
-    #
-    # TODO: may be a good idea to make ic global.  This would reduce the amount
-    # ugly exception-handling code.  See:
-    #
-    # http://www.mail-archive.com/vim_dev@googlegroups.com/msg18318/example_ibus.vim
-    #
-    ic = ibus.InputContext(bus, bus.current_input_contxt())
-    vim.command('let ibus_is_enabled = ' + str(ic.is_enabled()))
-except DBusException:
-    #
-    # dbus.exception.DBusException: org.freedesktop.DBus.Error.failed: No focused input context
-    # This happens occasionally, causing a long trace of errors in Vim.
-    # The exception is less harmful than the annoying long trace.
-    # Assume ibus is disabled and carry on
-    #
+    import ibus
+    from dbus.exceptions import DBusException
+    bus = ibus.Bus()
+    try:
+        #
+        # TODO: may be a good idea to make ic global.  This would reduce the amount
+        # ugly exception-handling code.  See:
+        #
+        # http://www.mail-archive.com/vim_dev@googlegroups.com/msg18318/example_ibus.vim
+        #
+        ic = ibus.InputContext(bus, bus.current_input_contxt())
+        vim.command('let ibus_is_enabled = ' + str(ic.is_enabled()))
+    except DBusException:
+        #
+        # dbus.exception.DBusException: org.freedesktop.DBus.Error.failed: No focused input context
+        # This happens occasionally, causing a long trace of errors in Vim.
+        # The exception is less harmful than the annoying long trace.
+        # Assume ibus is disabled and carry on
+        #
+        vim.command('let ibus_is_enabled = 0')
+except ImportError:
     vim.command('let ibus_is_enabled = 0')
 EOT
   return ibus_is_enabled
@@ -49,14 +52,17 @@ endfunction
 
 function! s:enable()
   python << EOT
-import ibus
-from dbus.exceptions import DBusException
-bus = ibus.Bus()
 try:
-    ic = ibus.InputContext(bus, bus.current_input_contxt())
-    if not ic.is_enabled():
-        ic.enable()
-except DBusException:
+    import ibus
+    from dbus.exceptions import DBusException
+    bus = ibus.Bus()
+    try:
+        ic = ibus.InputContext(bus, bus.current_input_contxt())
+        if not ic.is_enabled():
+            ic.enable()
+    except DBusException:
+        pass
+except ImportError:
     pass
 EOT
   return ''
@@ -64,14 +70,17 @@ endfunction
 
 function! s:disable()
   python << EOT
-import ibus
-from dbus.exceptions import DBusException
-bus = ibus.Bus()
 try:
-    ic = ibus.InputContext(bus, bus.current_input_contxt())
-    if ic.is_enabled():
-        ic.disable()
-except DBusException:
+    import ibus
+    from dbus.exceptions import DBusException
+    bus = ibus.Bus()
+    try:
+        ic = ibus.InputContext(bus, bus.current_input_contxt())
+        if ic.is_enabled():
+            ic.disable()
+    except DBusException:
+        pass
+except ImportError:
     pass
 EOT
   return ''
@@ -79,16 +88,19 @@ endfunction
 
 function! s:toggle()
   python << EOT
-import ibus
-from dbus.exceptions import DBusException
-bus = ibus.Bus()
 try:
-    ic = ibus.InputContext(bus, bus.current_input_contxt())
-    if ic.is_enabled():
-        ic.disable()
-    else:
-        ic.enable()
-except DBusException:
+    import ibus
+    from dbus.exceptions import DBusException
+    bus = ibus.Bus()
+    try:
+        ic = ibus.InputContext(bus, bus.current_input_contxt())
+        if ic.is_enabled():
+            ic.disable()
+        else:
+            ic.enable()
+    except DBusException:
+        pass
+except ImportError:
     pass
 EOT
   return ''


### PR DESCRIPTION
ibus が存在しない環境で使用してもエラーが出ないように、 ImportError をキャッチするようにしてみました。

参考までにパッチを書きましたが、私の Python 力は低いです:stuck_out_tongue_closed_eyes:
ベターな書き方があれば、修正して下さいませ。
